### PR TITLE
feat: add EditAction page with form fields and routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router";
-import { Login, Register, Dashboard, ActionDetail } from "./pages";
+import { Login, Register, Dashboard, ActionDetail, EditAction } from "./pages";
 import { PublicRoute } from "./routes/PublicRoute";
 import { useAuthStore } from "./stores/authStore";
 
@@ -45,6 +45,16 @@ export default function App() {
             </PublicRoute>
           }
         />
+
+        <Route
+          path="/activity/:id/edit"
+          element={
+            <PublicRoute>
+              <EditAction />
+            </PublicRoute>
+          }
+        />
+
         <Route path="/" element={<HomeRedirect />} />
         <Route path="*" element={<HomeRedirect />} />
       </Routes>

--- a/frontend/src/features/action-edit/components/ActionTypeField.tsx
+++ b/frontend/src/features/action-edit/components/ActionTypeField.tsx
@@ -1,0 +1,30 @@
+import { ChevronDown } from "lucide-react";
+import type { UseFormRegisterReturn } from "react-hook-form";
+import { ACTION_TYPES } from "../../dashboard/constants";
+
+interface ActionTypeFieldProps {
+  registration: UseFormRegisterReturn;
+  error?: string;
+}
+
+export function ActionTypeField({ registration, error }: ActionTypeFieldProps) {
+  return (
+    <div className="space-y-1">
+      <label className="text-sm font-semibold text-gray-700">Tipo de ação</label>
+      <div className="relative">
+        <select
+          className={`w-full appearance-none px-2 py-2.5 pr-8 text-xs text-gray-700 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow cursor-pointer ${error ? "border-red-300" : "border-gray-200"}`}
+          {...registration}
+        >
+          {ACTION_TYPES.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 size-5 text-gray-400 pointer-events-none" />
+      </div>
+      {error && <p className="text-sm text-red-600 px-1">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/features/action-edit/components/DateField.tsx
+++ b/frontend/src/features/action-edit/components/DateField.tsx
@@ -1,0 +1,21 @@
+import type { UseFormRegisterReturn } from "react-hook-form";
+
+interface DateFieldProps {
+  label: string;
+  registration: UseFormRegisterReturn;
+  error?: string;
+}
+
+export function DateField({ label, registration, error }: DateFieldProps) {
+  return (
+    <div className="space-y-1 min-w-0">
+      <label className="block text-sm font-semibold text-gray-700 truncate">{label}</label>
+      <input
+        type="date"
+        className={`w-full px-2 py-2.5 text-xs text-gray-700 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow ${error ? "border-red-300" : "border-gray-200"}`}
+        {...registration}
+      />
+      {error && <p className="text-xs text-red-600 px-1">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/features/action-edit/components/DescriptionField.tsx
+++ b/frontend/src/features/action-edit/components/DescriptionField.tsx
@@ -1,0 +1,22 @@
+import type { UseFormRegisterReturn } from "react-hook-form";
+
+interface DescriptionFieldProps {
+  registration: UseFormRegisterReturn;
+  error?: string;
+}
+
+export function DescriptionField({ registration, error }: DescriptionFieldProps) {
+  return (
+    <div className="flex flex-col h-full space-y-1">
+      <label className="text-sm font-semibold text-gray-700">Descrição</label>
+      <textarea
+        placeholder="Descreva os detalhes da ação..."
+        className={`w-full flex-1 min-h-[420px] px-4 py-3 text-sm text-gray-700 border rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow ${
+          error ? "border-red-300" : "border-gray-200"
+        }`}
+        {...registration}
+      />
+      {error && <p className="text-sm text-red-600 px-1">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/features/action-edit/components/ResponsibleCard.tsx
+++ b/frontend/src/features/action-edit/components/ResponsibleCard.tsx
@@ -1,0 +1,32 @@
+import type { Responsible } from "../types";
+
+interface ResponsibleCardProps {
+  responsible: Responsible;
+}
+
+export function ResponsibleCard({ responsible }: ResponsibleCardProps) {
+  return (
+    <div className="space-y-1">
+      <label className="text-sm font-semibold text-gray-700">Responsável</label>
+      <div className="flex items-center gap-4 p-4 border border-gray-200 rounded-xl">
+        <div className="size-14 rounded-full overflow-hidden shrink-0 bg-gray-100">
+          {responsible.avatarUrl ? (
+            <img
+              src={responsible.avatarUrl}
+              alt={responsible.name}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center bg-blue-100 text-blue-600 font-semibold text-lg">
+              {responsible.name.charAt(0)}
+            </div>
+          )}
+        </div>
+        <div>
+          <p className="text-base font-bold text-gray-900">{responsible.name}</p>
+          <p className="text-sm text-gray-500">{responsible.email}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/action-edit/components/SpotsField.tsx
+++ b/frontend/src/features/action-edit/components/SpotsField.tsx
@@ -1,0 +1,22 @@
+import type { UseFormRegisterReturn } from "react-hook-form";
+
+interface SpotsFieldProps {
+  registration: UseFormRegisterReturn;
+  error?: string;
+}
+
+export function SpotsField({ registration, error }: SpotsFieldProps) {
+  return (
+    <div className="space-y-1">
+      <label className="text-sm font-semibold text-gray-700">Qtde. de Vagas</label>
+      <input
+        type="number"
+        min={1}
+        placeholder="0"
+        className={`w-full px-2 py-2.5 text-xs text-gray-700 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow ${error ? "border-red-300" : "border-gray-200"}`}
+        {...registration}
+      />
+      {error && <p className="text-sm text-red-600 px-1">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/features/action-edit/components/TitleField.tsx
+++ b/frontend/src/features/action-edit/components/TitleField.tsx
@@ -1,0 +1,22 @@
+import type { UseFormRegisterReturn } from "react-hook-form";
+
+interface TitleFieldProps {
+  registration: UseFormRegisterReturn;
+  error?: string;
+}
+
+export function TitleField({ registration, error }: TitleFieldProps) {
+  return (
+    <div className="space-y-1">
+      <input
+        type="text"
+        placeholder="Título"
+        className={`w-full px-5 py-4 text-base border rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow ${
+          error ? "border-red-300" : "border-gray-200"
+        }`}
+        {...registration}
+      />
+      {error && <p className="text-sm text-red-600 px-1">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/features/action-edit/components/index.tsx
+++ b/frontend/src/features/action-edit/components/index.tsx
@@ -1,0 +1,6 @@
+export { TitleField } from "./TitleField";
+export { DescriptionField } from "./DescriptionField";
+export { DateField } from "./DateField";
+export { ActionTypeField } from "./ActionTypeField";
+export { SpotsField } from "./SpotsField";
+export { ResponsibleCard } from "./ResponsibleCard";

--- a/frontend/src/features/action-edit/services.ts
+++ b/frontend/src/features/action-edit/services.ts
@@ -1,0 +1,8 @@
+import type { ActionEditSchemaType } from "./validators";
+
+export async function updateAction(id: string, data: ActionEditSchemaType): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  // Uncomment para simular falha durante o desenvolvimento:
+  // throw new Error("Erro ao atualizar a ação. Tente novamente.");
+  console.log("Atualizando ação", id, data);
+}

--- a/frontend/src/features/action-edit/types.ts
+++ b/frontend/src/features/action-edit/types.ts
@@ -1,0 +1,16 @@
+import type { ActionType } from "../dashboard/types";
+
+export interface ActionEditFormData {
+  title: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  type: ActionType;
+  spots: number;
+}
+
+export interface Responsible {
+  name: string;
+  email: string;
+  avatarUrl?: string;
+}

--- a/frontend/src/features/action-edit/utils.ts
+++ b/frontend/src/features/action-edit/utils.ts
@@ -1,0 +1,20 @@
+import type { ActionType } from "../dashboard/types";
+import { ACTION_TYPES } from "../dashboard/constants";
+
+export function toInputDate(value: string): string {
+  const [day, month, year] = value.split("/");
+  if (!day || !month || !year) return "";
+  return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
+}
+
+export function fromInputDate(value: string): string {
+  const [year, month, day] = value.split("-");
+  if (!year || !month || !day) return "";
+  return `${day}/${month}/${year}`;
+}
+
+export function categoryToActionType(category: string): ActionType {
+  const normalized = category.trim().toLowerCase();
+  const match = ACTION_TYPES.find((option) => option.value === normalized);
+  return (match?.value ?? ACTION_TYPES[0].value) as ActionType;
+}

--- a/frontend/src/features/action-edit/validators.ts
+++ b/frontend/src/features/action-edit/validators.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const ActionEditSchema = z
+  .object({
+    title: z
+      .string()
+      .min(1, "O título é obrigatório")
+      .min(3, "O título deve ter no mínimo 3 caracteres"),
+    description: z
+      .string()
+      .min(1, "A descrição é obrigatória")
+      .min(10, "A descrição deve ter no mínimo 10 caracteres"),
+    startDate: z.string().min(1, "A data de início é obrigatória"),
+    endDate: z.string().min(1, "A data de encerramento é obrigatória"),
+    type: z.enum(["oficina", "palestra", "evento", "servico", "minicurso"], {
+      message: "Selecione um tipo de ação",
+    }),
+    spots: z.coerce
+      .number({ message: "Informe a quantidade de vagas" })
+      .int("A quantidade de vagas deve ser um número inteiro")
+      .positive("A quantidade de vagas deve ser maior que zero"),
+  })
+  .refine((data) => new Date(data.endDate) >= new Date(data.startDate), {
+    message: "A data de encerramento deve ser posterior à data de início",
+    path: ["endDate"],
+  });
+
+export type ActionEditSchemaType = z.infer<typeof ActionEditSchema>;

--- a/frontend/src/features/dashboard/components/DashboardShell.tsx
+++ b/frontend/src/features/dashboard/components/DashboardShell.tsx
@@ -17,7 +17,7 @@ export function DashboardShell({
     <div className="min-h-screen flex flex-col bg-gray-50" style={containerStyle}>
       {header && <header>{header}</header>}
 
-      <main className="flex-1 flex flex-col w-full">
+      <main className="flex flex-col w-full">
         {children}
       </main>
 

--- a/frontend/src/pages/EditAction.tsx
+++ b/frontend/src/pages/EditAction.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { Button } from "../components";
+import { useAuth } from "../hooks";
+import { DashboardShell } from "../features/dashboard/components/DashboardShell";
+import { DashboardHeader } from "../features/dashboard/components/DashboardHeader";
+import { Footer } from "../components/Footer";
+import {
+  TitleField,
+  DescriptionField,
+  DateField,
+  ActionTypeField,
+  SpotsField,
+  ResponsibleCard,
+} from "../features/action-edit/components";
+import { ActionEditSchema, type ActionEditSchemaType } from "../features/action-edit/validators";
+import { getActionById } from "../features/action-detail/services";
+import { updateAction } from "../features/action-edit/services";
+import { toInputDate, fromInputDate, categoryToActionType } from "../features/action-edit/utils";
+
+export function EditAction() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const { user } = useAuth();
+
+  const [isLoadingAction, setIsLoadingAction] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm({
+    resolver: zodResolver(ActionEditSchema),
+    mode: "onSubmit",
+  });
+
+  useEffect(() => {
+    if (!id) {
+      setNotFound(true);
+      setIsLoadingAction(false);
+      return;
+    }
+
+    let isMounted = true;
+
+    (async () => {
+      const action = await getActionById(id);
+
+      if (!isMounted) return;
+
+      if (!action) {
+        setNotFound(true);
+        setIsLoadingAction(false);
+        return;
+      }
+
+      reset({
+        title: action.title,
+        description: action.fullDescription,
+        startDate: toInputDate(action.startDate),
+        endDate: toInputDate(action.endDate),
+        type: categoryToActionType(action.category),
+        spots: action.totalSlots,
+      });
+
+      setIsLoadingAction(false);
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [id, reset]);
+
+  const onSubmit = async (data: ActionEditSchemaType) => {
+    if (!id) return;
+
+    await updateAction(id, {
+      ...data,
+      startDate: fromInputDate(data.startDate),
+      endDate: fromInputDate(data.endDate),
+    } as ActionEditSchemaType);
+
+    navigate(`/activity/${id}`);
+  };
+
+  const responsible = {
+    name: user?.fullName ?? "Nome Exemplo",
+    email: user?.email ?? "meu.email@exemplo.com",
+  };
+
+  if (isLoadingAction) {
+    return (
+      <DashboardShell
+        header={<DashboardHeader onOpenRegister={() => {}} />}
+        footer={<Footer />}
+      >
+        <div className="flex-1 flex items-center justify-center py-20">
+          <p className="text-gray-500">Carregando...</p>
+        </div>
+      </DashboardShell>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <DashboardShell
+        header={<DashboardHeader onOpenRegister={() => {}} />}
+        footer={<Footer />}
+      >
+        <div className="flex-1 flex items-center justify-center py-20">
+          <p className="text-gray-500">Ação não encontrada.</p>
+        </div>
+      </DashboardShell>
+    );
+  }
+
+  return (
+    <DashboardShell
+      header={<DashboardHeader onOpenRegister={() => {}} />}
+      footer={<Footer />}
+      containerStyle={{ backgroundColor: "#E0F6F6" }}
+    >
+        <div className="max-w-10xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-10">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="bg-white rounded-2xl shadow-sm px-6 pt-6 pb-6 md:px-10 md:pt-10 md:pb-6"
+          >
+            <TitleField registration={register("title")} error={errors.title?.message} />
+
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mt-8">
+              <div className="lg:col-span-2">
+                <DescriptionField
+                  registration={register("description")}
+                  error={errors.description?.message}
+                />
+              </div>
+
+              <div className="flex flex-col gap-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                  <DateField
+                    label="Data de início"
+                    registration={register("startDate")}
+                    error={errors.startDate?.message}
+                  />
+                  <DateField
+                    label="Data de encerramento"
+                    registration={register("endDate")}
+                    error={errors.endDate?.message}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <ActionTypeField
+                    registration={register("type")}
+                    error={errors.type?.message}
+                  />
+                  <SpotsField
+                    registration={register("spots")}
+                    error={errors.spots?.message}
+                  />
+                </div>
+
+                <ResponsibleCard responsible={responsible} />
+
+                <div className="flex justify-end gap-3 pt-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => navigate(-1)}
+                  >
+                    Cancelar
+                  </Button>
+                  <Button
+                    type="submit"
+                    size="sm"
+                    variant="navy"
+                    isLoading={isSubmitting}
+                  >
+                    Salvar alterações
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </form>
+        </div>
+    </DashboardShell>
+  );
+}

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -2,3 +2,4 @@ export { Login } from "./Login";
 export { Register } from "./Register";
 export { Dashboard } from "./Dashboard";
 export { ActionDetail } from "./ActionDetail";
+export { EditAction } from "./EditAction";


### PR DESCRIPTION
### Changelog

- Criação de recursos/edição de ação com tipos, validadores, utilitários, serviços e componentes
- Adição dos campos TitleField, DescriptionField, DateField, ActionTypeField, SpotsField e ResponsibleCard
- Preenchimento previamente os campos do formulário usando getActionById de action-detail
- O cartão de responsável é preenchido automaticamente com os dados do usuário logado (nome completo + e-mail) com fallback para acesso de desenvolvedor
- Adição da rota /activity/:id/edit em App.tsx
- Foi reutilizado o padrão de layout DashboardShell, DashboardHeader e Footer

##

### Como testar:

1. Acesse diretamente pela rota (sem precisar de login)
[(http://localhost:5173/activity/1/edit]
2. IDs disponíveis nos mocks: 1, 2, 3, 4
3. Verifique se o formulário carrega pré-preenchido com os dados da ação (mocke por enquanto)
4. Teste a validação deixando campos obrigatórios em branco e clicando em "Salvar alterações"
5. Teste a data de encerramento anterior à data de início (deve mostrar erro)
